### PR TITLE
librealsense: fix md5sum and sha256sum

### DIFF
--- a/recipes-support/librealsense/librealsense_0.9.2.bb
+++ b/recipes-support/librealsense/librealsense_0.9.2.bb
@@ -1,8 +1,8 @@
 require librealsense.inc
 
 SRC_URI = "https://github.com/IntelRealSense/librealsense/archive/v${PV}.tar.gz"
-SRC_URI[md5sum] = "4d41105e56b02a59fff944cd6e41dc2c"
-SRC_URI[sha256sum] = "c4682aa8ba4e55f09d8f7fcb7745e1b0ec95124811c4bea9ded1348193480ec4"
+SRC_URI[md5sum] = "8968c0cf709bd92e0c05b434f3580b5d"
+SRC_URI[sha256sum] = "86df7c1aea864fef964804effd9d08733be66283e6b69152538f0d143b4dda07"
 
 PR = "r0"
 


### PR DESCRIPTION
This patch fixes the following error:
ERROR: librealsense-0.9.2-r0 do_fetch: Fetcher failure for URL:
'v0.9.2.tar.gz'. Checksum mismatch!

If this change is expected (e.g. you have upgraded to a new version without updating
the checksums) then you can use these lines within the recipe:

SRC_URI[md5sum] = "8968c0cf709bd92e0c05b434f3580b5d"
SRC_URI[sha256sum] = "86df7c1aea864fef964804effd9d08733be66283e6b69152538f0d143b4dda07"

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
